### PR TITLE
fix: resolve bugs #65 #66 #69 #74

### DIFF
--- a/app/api/fetch-chart/route.ts
+++ b/app/api/fetch-chart/route.ts
@@ -37,7 +37,7 @@ export async function POST(request: Request) {
       tgzPath = dest;
     } else if (body.repoUrl && body.chartName) {
       // Use helm pull directly
-      assertSafeUrl(body.repoUrl);
+      await assertSafeUrl(body.repoUrl);
       if (!/^[a-zA-Z0-9_-]+$/.test(body.chartName)) {
         return NextResponse.json(
           { error: "Invalid chart name. Chart names must only contain letters, digits, hyphens, and underscores." },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -73,8 +73,17 @@ function loadHistory(): HistoryEntry[] {
   try {
     const now = Date.now();
     const all: HistoryEntry[] = JSON.parse(localStorage.getItem(HISTORY_KEY) ?? "[]");
-    // Prune entries that exceed TTL (or are legacy entries without savedAt — keep them)
-    return all.filter((h) => h.savedAt === undefined || now - h.savedAt < HISTORY_TTL_MS);
+    // Prune entries that exceed TTL. For legacy entries without savedAt, infer it from loadedAt.
+    return all.flatMap((h) => {
+      const savedAt =
+        typeof h.savedAt === "number" && Number.isFinite(h.savedAt)
+          ? h.savedAt
+          : Date.parse(h.loadedAt);
+      if (!Number.isFinite(savedAt) || now - savedAt >= HISTORY_TTL_MS) {
+        return [];
+      }
+      return [{ ...h, savedAt }];
+    });
   } catch {
     return [];
   }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,6 +29,8 @@ import { analyzeChartSuggestions, applySuggestionToEnv } from "@/lib/chartSugges
 
 const HISTORY_KEY = "helm-viz-history";
 const MAX_HISTORY = 8;
+/** History entries older than this (ms) are pruned on load. */
+const HISTORY_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 const MAX_VALUES_TREE_ENTRIES_FOR_LLM = 200;
 const THEME_KEY = "helm-viz-theme";
 const THEMES = [
@@ -45,6 +47,8 @@ export interface HistoryEntry {
   source: "workspace" | "upload" | "artifacthub" | "github";
   url?: string;
   loadedAt: string;
+  /** Unix timestamp (ms) when the entry was saved. Used for TTL pruning. */
+  savedAt?: number;
   result: ChartRenderResult;
 }
 
@@ -67,15 +71,19 @@ function getEnvResult(result: ChartRenderResult | null, env: string): EnvRenderR
 
 function loadHistory(): HistoryEntry[] {
   try {
-    return JSON.parse(localStorage.getItem(HISTORY_KEY) ?? "[]");
+    const now = Date.now();
+    const all: HistoryEntry[] = JSON.parse(localStorage.getItem(HISTORY_KEY) ?? "[]");
+    // Prune entries that exceed TTL (or are legacy entries without savedAt — keep them)
+    return all.filter((h) => h.savedAt === undefined || now - h.savedAt < HISTORY_TTL_MS);
   } catch {
     return [];
   }
 }
 
 function saveHistory(entry: HistoryEntry) {
+  const withTimestamp: HistoryEntry = { ...entry, savedAt: Date.now() };
   const prev = loadHistory().filter((h) => h.name !== entry.name || h.source !== entry.source);
-  const next = [entry, ...prev].slice(0, MAX_HISTORY);
+  const next = [withTimestamp, ...prev].slice(0, MAX_HISTORY);
   localStorage.setItem(HISTORY_KEY, JSON.stringify(next));
 }
 
@@ -585,6 +593,21 @@ export default function Home() {
             >
               <X className="w-4 h-4" />
             </button>
+          </div>
+        );
+      })()}
+
+      {/* JS renderer stub warnings banner */}
+      {(() => {
+        const stubs = currentEnvResult?.jsRendererWarnings ?? [];
+        if (stubs.length === 0) return null;
+        return (
+          <div className="shrink-0 bg-sky-950/60 border-b border-sky-800/60 px-4 py-2 flex items-start gap-3">
+            <AlertTriangle className="w-4 h-4 text-sky-400 shrink-0 mt-0.5" />
+            <p className="flex-1 text-sky-200 text-xs leading-snug">
+              ⚠️ This chart was rendered by the built-in JS fallback (helm CLI not found). The following functions used stub implementations and may produce inaccurate output:{" "}
+              <span className="font-mono">{stubs.join(", ")}</span>.
+            </p>
           </div>
         );
       })()}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -93,7 +93,15 @@ function saveHistory(entry: HistoryEntry) {
   const withTimestamp: HistoryEntry = { ...entry, savedAt: Date.now() };
   const prev = loadHistory().filter((h) => h.name !== entry.name || h.source !== entry.source);
   const next = [withTimestamp, ...prev].slice(0, MAX_HISTORY);
-  localStorage.setItem(HISTORY_KEY, JSON.stringify(next));
+
+  for (let end = next.length; end > 0; end -= 1) {
+    try {
+      localStorage.setItem(HISTORY_KEY, JSON.stringify(next.slice(0, end)));
+      return;
+    } catch {
+      // Retry with fewer entries if storage is full/unavailable.
+    }
+  }
 }
 
 /** Count resources grouped by kind from the active environment */

--- a/components/ResourceGraph.tsx
+++ b/components/ResourceGraph.tsx
@@ -11,6 +11,7 @@ import {
   useReactFlow,
   getNodesBounds,
   getViewportForBounds,
+  type Node,
   type NodeMouseHandler,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
@@ -45,8 +46,17 @@ const nodeTypes = {
   resourceNode: ResourceNode,
 };
 
-const IMAGE_WIDTH = 1920;
-const IMAGE_HEIGHT = 1080;
+const IMAGE_PADDING = 120;
+const IMAGE_MAX_DIM = 8192;
+
+function getExportDimensions(nodes: Node[]) {
+  if (nodes.length === 0) return { width: 1920, height: 1080 };
+  const bounds = getNodesBounds(nodes);
+  return {
+    width: Math.min(Math.max(Math.ceil(bounds.width) + IMAGE_PADDING * 2, 800), IMAGE_MAX_DIM),
+    height: Math.min(Math.max(Math.ceil(bounds.height) + IMAGE_PADDING * 2, 600), IMAGE_MAX_DIM),
+  };
+}
 const VIEWPORT_SELECTOR = ".react-flow__viewport";
 const THEME_VISUALS = {
   light: {
@@ -97,22 +107,23 @@ const ExportController = forwardRef<ResourceGraphHandle, ExportControllerProps>(
 
     function getExportViewport() {
       const allNodes = getNodes();
+      const { width, height } = getExportDimensions(allNodes);
       const bounds = getNodesBounds(allNodes);
-      return getViewportForBounds(bounds, IMAGE_WIDTH, IMAGE_HEIGHT, 0.05, 2, 0.1);
+      return { viewport: getViewportForBounds(bounds, width, height, 0.05, 2, 0.1), width, height };
     }
 
     useImperativeHandle(ref, () => ({
       async exportPng() {
         const el = containerRef.current?.querySelector<HTMLElement>(VIEWPORT_SELECTOR);
         if (!el) return;
-        const { x, y, zoom } = getExportViewport();
+        const { viewport: { x, y, zoom }, width, height } = getExportViewport();
         const dataUrl = await toPng(el, {
           backgroundColor: exportBackground,
-          width: IMAGE_WIDTH,
-          height: IMAGE_HEIGHT,
+          width,
+          height,
           style: {
-            width: `${IMAGE_WIDTH}px`,
-            height: `${IMAGE_HEIGHT}px`,
+            width: `${width}px`,
+            height: `${height}px`,
             transform: `translate(${x}px, ${y}px) scale(${zoom})`,
           },
         });
@@ -125,14 +136,14 @@ const ExportController = forwardRef<ResourceGraphHandle, ExportControllerProps>(
       async exportSvg() {
         const el = containerRef.current?.querySelector<HTMLElement>(VIEWPORT_SELECTOR);
         if (!el) return;
-        const { x, y, zoom } = getExportViewport();
+        const { viewport: { x, y, zoom }, width, height } = getExportViewport();
         const dataUrl = await toSvg(el, {
           backgroundColor: exportBackground,
-          width: IMAGE_WIDTH,
-          height: IMAGE_HEIGHT,
+          width,
+          height,
           style: {
-            width: `${IMAGE_WIDTH}px`,
-            height: `${IMAGE_HEIGHT}px`,
+            width: `${width}px`,
+            height: `${height}px`,
             transform: `translate(${x}px, ${y}px) scale(${zoom})`,
           },
         });

--- a/lib/chartRenderer.ts
+++ b/lib/chartRenderer.ts
@@ -60,7 +60,7 @@ export async function renderChart(chartDir: string): Promise<NextResponse> {
     renderTargets.map(async ({ vf, env }) => {
       try {
         const vfArr = vf ? [vf] : [];
-        const rendered = await runHelmTemplate(chartDir, "release", vfArr);
+        const { yaml: rendered, jsRendererWarnings } = await runHelmTemplate(chartDir, "release", vfArr);
         const resources = parseMultiDocYaml(rendered);
         const valuesYaml = vf ? await readFile(vf, "utf-8") : "";
         const valuesTree = extractValuesEntries(valuesYaml, env, templateFiles);
@@ -73,6 +73,7 @@ export async function renderChart(chartDir: string): Promise<NextResponse> {
           renderedManifest: rendered,
           valuesTree,
           graph,
+          ...(jsRendererWarnings.length > 0 ? { jsRendererWarnings } : {}),
         } as EnvRenderResult & { graph: ReturnType<typeof buildGraph> };
       } catch (err) {
         return {

--- a/lib/helmRunner.ts
+++ b/lib/helmRunner.ts
@@ -66,14 +66,14 @@ function assertValidChartVersion(version: string): void {
  * @param releaseName  Release name passed to helm template
  * @param valuesFiles  Paths to values YAML files (-f flags)
  * @param extraArgs    Any extra args (only used when CLI is available)
- * @returns Multi-document YAML string
+ * @returns { yaml: string; jsRendererWarnings: string[] }
  */
 export async function runHelmTemplate(
   chartDir: string,
   releaseName = "release",
   valuesFiles: string[] = [],
   extraArgs: string[] = []
-): Promise<string> {
+): Promise<{ yaml: string; jsRendererWarnings: string[] }> {
   assertValidChartDir(chartDir);
 
   // Try CLI first; fall back to JS renderer if unavailable
@@ -105,12 +105,13 @@ export async function runHelmTemplate(
     if (stderr && stderr.trim()) {
       console.warn("[helmRunner] helm template stderr:", stderr.trim());
     }
-    return stdout;
+    return { yaml: stdout, jsRendererWarnings: [] };
   }
 
   // JS fallback
   console.info("[helmRunner] helm CLI not found — using built-in JS renderer");
-  return renderHelmChartJS(chartDir, releaseName, valuesFiles);
+  const { yaml, stubsUsed } = await renderHelmChartJS(chartDir, releaseName, valuesFiles);
+  return { yaml, jsRendererWarnings: stubsUsed };
 }
 
 /**

--- a/lib/helmTemplateRenderer.ts
+++ b/lib/helmTemplateRenderer.ts
@@ -20,6 +20,10 @@ import { existsSync } from "fs";
 import path from "path";
 import yaml from "js-yaml";
 
+// Module-level set populated by callBuiltin() when a stub function is invoked.
+// Reset at the start of each renderHelmChartJS call.
+const _stubsInvokedThisRender = new Set<string>();
+
 // ─────────────────────────────────────────────────────────────
 // Public API
 // ─────────────────────────────────────────────────────────────
@@ -43,13 +47,16 @@ export interface HelmRenderContext {
 
 /**
  * Render all templates in chartDir, merging the provided values files.
- * Returns a multi-document YAML string (same format as `helm template` output).
+ * Returns a multi-document YAML string (same format as `helm template` output)
+ * and a list of stub function names that were invoked (empty if none).
  */
 export async function renderHelmChartJS(
   chartDir: string,
   releaseName: string,
   valuesFiles: string[]
-): Promise<string> {
+): Promise<{ yaml: string; stubsUsed: string[] }> {
+  // Reset stub tracking for this render run.
+  _stubsInvokedThisRender.clear();
   // 1. Load Chart.yaml
   const chartYaml = yaml.load(
     await readFile(path.join(chartDir, "Chart.yaml"), "utf-8")
@@ -174,7 +181,7 @@ export async function renderHelmChartJS(
     }
   }
 
-  return parts.join("\n");
+  return { yaml: parts.join("\n"), stubsUsed: Array.from(_stubsInvokedThisRender) };
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -791,6 +798,7 @@ function applyFunc(
     case "b64dec":
       return Buffer.from(String(args[0] ?? ""), "base64").toString("utf-8");
     case "sha256sum":
+      _stubsInvokedThisRender.add("sha256sum");
       return String(args[0] ?? ""); // stub — no crypto dep needed for rendering
 
     // ── YAML / indentation ────────────────────────────────────
@@ -1090,8 +1098,10 @@ function applyFunc(
     case "randAlpha":
     case "randNumeric":
     case "randAscii":
+      _stubsInvokedThisRender.add(fn);
       return "x".repeat(Math.max(1, Number(args[0] ?? 5)));
     case "uuidv4":
+      _stubsInvokedThisRender.add("uuidv4");
       return "00000000-0000-4000-8000-000000000000"; // deterministic stub
     case "now":
       return new Date().toISOString();

--- a/lib/helmTemplateRenderer.ts
+++ b/lib/helmTemplateRenderer.ts
@@ -19,11 +19,57 @@ import { readFile, readdir } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
 import yaml from "js-yaml";
+import { AsyncLocalStorage } from "async_hooks";
 
-// Module-level set populated by callBuiltin() when a stub function is invoked.
-// Reset at the start of each renderHelmChartJS call.
-const _stubsInvokedThisRender = new Set<string>();
+// Per-render stub tracking. The Set-like wrapper resolves storage from the
+// current async execution context so concurrent renders do not share state.
+const _stubsInvokedThisRenderStorage = new AsyncLocalStorage<Set<string>>();
 
+function getStubsInvokedThisRenderSet(): Set<string> {
+  const current = _stubsInvokedThisRenderStorage.getStore();
+  if (current) return current;
+
+  const created = new Set<string>();
+  _stubsInvokedThisRenderStorage.enterWith(created);
+  return created;
+}
+
+const _stubsInvokedThisRender = {
+  clear(): void {
+    _stubsInvokedThisRenderStorage.enterWith(new Set<string>());
+  },
+  add(value: string) {
+    getStubsInvokedThisRenderSet().add(value);
+    return this;
+  },
+  has(value: string): boolean {
+    return getStubsInvokedThisRenderSet().has(value);
+  },
+  delete(value: string): boolean {
+    return getStubsInvokedThisRenderSet().delete(value);
+  },
+  values(): IterableIterator<string> {
+    return getStubsInvokedThisRenderSet().values();
+  },
+  keys(): IterableIterator<string> {
+    return getStubsInvokedThisRenderSet().keys();
+  },
+  entries(): IterableIterator<[string, string]> {
+    return getStubsInvokedThisRenderSet().entries();
+  },
+  forEach(
+    callbackfn: (value: string, value2: string, set: Set<string>) => void,
+    thisArg?: unknown
+  ): void {
+    getStubsInvokedThisRenderSet().forEach(callbackfn, thisArg);
+  },
+  get size(): number {
+    return getStubsInvokedThisRenderSet().size;
+  },
+  [Symbol.iterator](): IterableIterator<string> {
+    return getStubsInvokedThisRenderSet()[Symbol.iterator]();
+  },
+};
 // ─────────────────────────────────────────────────────────────
 // Public API
 // ─────────────────────────────────────────────────────────────

--- a/types/helm.ts
+++ b/types/helm.ts
@@ -86,6 +86,8 @@ export interface EnvRenderResult {
   valuesTree: ValuesTree;
   renderedManifest?: string;
   renderError?: string;
+  /** Non-empty when the pure-JS fallback renderer was used and invoked stub functions. */
+  jsRendererWarnings?: string[];
 }
 
 // ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes 4 bugs identified in the issues tracker.

### #65 — Missing `await` on SSRF guard (Critical)
- `assertSafeUrl()` is async but was called without `await` in `app/api/fetch-chart/route.ts`
- SSRF protection was silently bypassed; now properly awaited

### #66 — PNG export clipped at fixed 1920×1080
- Replaced hardcoded `IMAGE_WIDTH/HEIGHT` constants with `getExportDimensions(nodes)`
- Dynamically computes bounds from actual node positions + 120px padding, capped at 8192px

### #69 — No warning when JS renderer uses stub functions
- Added `_stubsInvokedThisRender` tracking in `helmTemplateRenderer.ts`
- Stubs tracked: `sha256sum`, `uuidv4`, `randAlpha*`, `randNumeric`, `randAscii`
- Propagated through `runHelmTemplate` → `EnvRenderResult.jsRendererWarnings`
- UI shows a blue info banner listing the stub functions

### #74 — localStorage history has no TTL
- Added `HISTORY_TTL_MS = 7 days` constant
- `saveHistory()` stamps `savedAt: Date.now()` on each entry
- `loadHistory()` prunes entries older than 7 days

Closes #65, #66, #69, #74