### PR TITLE
feat: enhancements #67 #68 #72 #73 #75

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -50,6 +50,34 @@ const PROMPT_ENTRY_LIMIT = 200;
 // Server-side limits to prevent oversized or abusive requests.
 const MAX_MESSAGES = 50;
 const MAX_MESSAGE_CHARS = 4000;
+/** Maximum tokens the LLM may generate in a single response. Override with OPENAI_MAX_TOKENS env var. */
+const MAX_RESPONSE_TOKENS = parseInt(process.env.OPENAI_MAX_TOKENS ?? "1200", 10);
+/** Rough token budget for the full prompt (system + history). 1 token ≈ 4 chars. */
+const MAX_PROMPT_CHARS = 60_000; // ~15k tokens — safe for gpt-4o-mini 128k context
+
+// ── In-memory rate limiter (per IP, sliding window) ──────────────────────────
+const _rateLimitMap = new Map<string, number[]>();
+/** Max requests per IP per window. */
+const RATE_LIMIT_MAX = parseInt(process.env.CHAT_RATE_LIMIT_MAX ?? "30", 10);
+/** Sliding window in milliseconds. */
+const RATE_LIMIT_WINDOW_MS = parseInt(process.env.CHAT_RATE_LIMIT_WINDOW_MS ?? "60000", 10);
+
+function checkRateLimit(ip: string): boolean {
+  const now = Date.now();
+  const windowStart = now - RATE_LIMIT_WINDOW_MS;
+  const timestamps = (_rateLimitMap.get(ip) ?? []).filter((t) => t > windowStart);
+  if (timestamps.length >= RATE_LIMIT_MAX) return false;
+  timestamps.push(now);
+  _rateLimitMap.set(ip, timestamps);
+  // Prevent unbounded map growth: prune IPs not seen for 10 minutes
+  if (_rateLimitMap.size > 10_000) {
+    for (const [key, ts] of _rateLimitMap) {
+      if (ts[ts.length - 1] < now - 10 * 60_000) _rateLimitMap.delete(key);
+    }
+  }
+  return true;
+}
+
 
 function buildSystemPrompt(chartContext: MinimalChartContext | null, activeEnv: string): string {
   if (!chartContext) {
@@ -142,6 +170,18 @@ function buildSystemPrompt(chartContext: MinimalChartContext | null, activeEnv: 
 }
 
 export async function POST(request: Request) {
+  // ── Rate limiting ────────────────────────────────────────────
+  const ip =
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    request.headers.get("x-real-ip") ??
+    "unknown";
+  if (!checkRateLimit(ip)) {
+    return NextResponse.json(
+      { error: `Rate limit exceeded. Maximum ${RATE_LIMIT_MAX} requests per ${RATE_LIMIT_WINDOW_MS / 1000}s.` },
+      { status: 429 }
+    );
+  }
+
   const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) {
     return NextResponse.json(
@@ -190,6 +230,18 @@ export async function POST(request: Request) {
     ...messages.map((m) => ({ role: m.role, content: m.content })),
   ];
 
+  // ── Prompt size guard ─────────────────────────────────────────
+  const totalChars = openaiMessages.reduce((sum, m) => sum + m.content.length, 0);
+  if (totalChars > MAX_PROMPT_CHARS) {
+    return NextResponse.json(
+      {
+        error: `Chart context is too large to send to the LLM (${totalChars.toLocaleString()} chars, limit ${MAX_PROMPT_CHARS.toLocaleString()}). ` +
+          "Try loading a smaller chart or reducing the number of environments.",
+      },
+      { status: 413 }
+    );
+  }
+
   let upstream: Response;
   try {
     upstream = await fetch(`${baseUrl}/chat/completions`, {
@@ -198,7 +250,7 @@ export async function POST(request: Request) {
         "Content-Type": "application/json",
         Authorization: `Bearer ${apiKey}`,
       },
-      body: JSON.stringify({ model, messages: openaiMessages, stream: true }),
+      body: JSON.stringify({ model, messages: openaiMessages, stream: true, max_tokens: MAX_RESPONSE_TOKENS }),
       signal: request.signal,
     });
   } catch (err) {

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -50,17 +50,24 @@ const PROMPT_ENTRY_LIMIT = 200;
 // Server-side limits to prevent oversized or abusive requests.
 const MAX_MESSAGES = 50;
 const MAX_MESSAGE_CHARS = 4000;
+
+function getClampedEnvInt(name: string, defaultValue: number, minValue: number): number {
+  const parsed = parseInt(process.env[name] ?? "", 10);
+  if (!Number.isFinite(parsed)) return defaultValue;
+  return Math.max(minValue, parsed);
+}
+
 /** Maximum tokens the LLM may generate in a single response. Override with OPENAI_MAX_TOKENS env var. */
-const MAX_RESPONSE_TOKENS = parseInt(process.env.OPENAI_MAX_TOKENS ?? "1200", 10);
+const MAX_RESPONSE_TOKENS = getClampedEnvInt("OPENAI_MAX_TOKENS", 1200, 1);
 /** Rough token budget for the full prompt (system + history). 1 token ≈ 4 chars. */
 const MAX_PROMPT_CHARS = 60_000; // ~15k tokens — safe for gpt-4o-mini 128k context
 
 // ── In-memory rate limiter (per IP, sliding window) ──────────────────────────
 const _rateLimitMap = new Map<string, number[]>();
 /** Max requests per IP per window. */
-const RATE_LIMIT_MAX = parseInt(process.env.CHAT_RATE_LIMIT_MAX ?? "30", 10);
+const RATE_LIMIT_MAX = getClampedEnvInt("CHAT_RATE_LIMIT_MAX", 30, 1);
 /** Sliding window in milliseconds. */
-const RATE_LIMIT_WINDOW_MS = parseInt(process.env.CHAT_RATE_LIMIT_WINDOW_MS ?? "60000", 10);
+const RATE_LIMIT_WINDOW_MS = getClampedEnvInt("CHAT_RATE_LIMIT_WINDOW_MS", 60000, 1);
 
 function checkRateLimit(ip: string): boolean {
   const now = Date.now();

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -123,6 +123,9 @@ const KIND_BADGE_COLOR: Partial<Record<K8sKind, string>> = {
   ConfigMap: "bg-teal-900 text-teal-300 border-teal-700",
   ServiceAccount: "bg-gray-700 text-gray-300 border-gray-600",
   Secret: "bg-red-900 text-red-300 border-red-700",
+  NetworkPolicy: "bg-rose-900 text-rose-300 border-rose-700",
+  PodDisruptionBudget: "bg-indigo-900 text-indigo-300 border-indigo-700",
+  CustomResourceDefinition: "bg-amber-900 text-amber-300 border-amber-700",
 };
 
 const KIND_LABEL: Partial<Record<K8sKind, string>> = {
@@ -130,6 +133,9 @@ const KIND_LABEL: Partial<Record<K8sKind, string>> = {
   HorizontalPodAutoscaler: "HPA",
   PersistentVolumeClaim: "PVC",
   ServiceAccount: "SA",
+  NetworkPolicy: "NetPol",
+  PodDisruptionBudget: "PDB",
+  CustomResourceDefinition: "CRD",
 };
 
 export default function Home() {
@@ -139,6 +145,7 @@ export default function Home() {
   const [selectedResource, setSelectedResource] = useState<ResourceNodeData | null>(null);
   const [highlightedKeys, setHighlightedKeys] = useState<string[]>([]);
   const [showLoader, setShowLoader] = useState(true);
+  const [isRendering, setIsRendering] = useState(false);
   const [valuesOpen, setValuesOpen] = useState(true);
   const [history, setHistory] = useState<HistoryEntry[]>([]);
   const [showDiffPanel, setShowDiffPanel] = useState(false);
@@ -169,6 +176,7 @@ export default function Home() {
 
   useEffect(() => {
     setHistory(loadHistory());
+    setIsRendering(true);
     fetch("/api/workspace-chart")
       .then((r) => r.json())
       .then((data: ChartRenderResult) => {
@@ -177,7 +185,8 @@ export default function Home() {
           setShowLoader(false);
         }
       })
-      .catch(() => {});
+      .catch(() => {})
+      .finally(() => setIsRendering(false));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -567,7 +576,7 @@ export default function Home() {
       {showLoader && (
         <div className="absolute inset-0 z-50 flex items-center justify-center bg-zinc-950/90 backdrop-blur-sm p-6">
           <div className="w-full max-w-2xl">
-            <ChartLoader onLoad={handleChartLoad} history={history} />
+            <ChartLoader onLoad={handleChartLoad} history={history} onRenderingChange={setIsRendering} />
             {chartResult && (
               <button
                 onClick={() => setShowLoader(false)}
@@ -640,7 +649,17 @@ export default function Home() {
 
       <div className="flex flex-1 overflow-hidden">
         <div className="flex-1 relative overflow-hidden">
-          {!chartResult && !showLoader && (
+          {/* Rendering overlay — shown during workspace auto-load */}
+          {isRendering && (
+            <div className="absolute inset-0 z-30 flex flex-col items-center justify-center bg-zinc-950/80 backdrop-blur-sm gap-3">
+              <svg className="w-8 h-8 text-blue-400 animate-spin" viewBox="0 0 24 24" fill="none">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+              </svg>
+              <p className="text-zinc-300 text-sm font-medium">Rendering chart…</p>
+            </div>
+          )}
+          {!chartResult && !showLoader && !isRendering && (
             <WelcomeScreen onLoadChart={() => setShowLoader(true)} />
           )}
           {currentEnvResult?.renderError ? (

--- a/components/ChartLoader.tsx
+++ b/components/ChartLoader.tsx
@@ -27,9 +27,11 @@ const POPULAR_CHARTS = [
 interface ChartLoaderProps {
   onLoad: (result: ChartRenderResult, source: "workspace" | "upload" | "artifacthub" | "github", url?: string) => void;
   history?: HistoryEntry[];
+  /** Called with true when a fetch starts, false when it ends — allows parent to show a rendering overlay. */
+  onRenderingChange?: (rendering: boolean) => void;
 }
 
-export function ChartLoader({ onLoad, history = [] }: ChartLoaderProps) {
+export function ChartLoader({ onLoad, history = [], onRenderingChange }: ChartLoaderProps) {
   const [activeTab, setActiveTab] = useState<Tab>(history.length > 0 ? "history" : "workspace");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -168,6 +170,7 @@ export function ChartLoader({ onLoad, history = [] }: ChartLoaderProps) {
 
   async function fetchWithLoading(fn: () => Promise<Response>, source: "workspace" | "upload" | "artifacthub" | "github", url?: string) {
     setLoading(true);
+    onRenderingChange?.(true);
     setError(null);
     setValidationIssues([]);
 
@@ -201,6 +204,7 @@ export function ChartLoader({ onLoad, history = [] }: ChartLoaderProps) {
       setError(e instanceof Error ? e.message : "Request failed");
     } finally {
       setLoading(false);
+      onRenderingChange?.(false);
       // Brief delay so the user sees the completed bar before it disappears
       const PROGRESS_COMPLETION_DELAY_MS = 600;
       setTimeout(() => setProgressStep(-1), PROGRESS_COMPLETION_DELAY_MS);

--- a/lib/chartRenderer.ts
+++ b/lib/chartRenderer.ts
@@ -15,6 +15,27 @@ export function extractEnvName(valuesFilePath: string): string {
   return parts.length > 1 ? parts[parts.length - 1] : "default";
 }
 
+/** Run tasks with bounded concurrency. */
+async function runWithConcurrency<T>(
+  tasks: Array<() => Promise<T>>,
+  concurrency: number
+): Promise<T[]> {
+  const results: T[] = new Array(tasks.length);
+  let nextIdx = 0;
+  async function worker() {
+    while (nextIdx < tasks.length) {
+      const i = nextIdx++;
+      results[i] = await tasks[i]();
+    }
+  }
+  const workers = Array.from({ length: Math.min(concurrency, tasks.length) }, worker);
+  await Promise.all(workers);
+  return results;
+}
+
+/** Maximum number of environments rendered concurrently. */
+const RENDER_CONCURRENCY = 3;
+
 export async function renderChart(chartDir: string): Promise<NextResponse> {
   // Run structural validation first — returns actionable errors/warnings
   const validation = await validateChart(chartDir);
@@ -56,8 +77,8 @@ export async function renderChart(chartDir: string): Promise<NextResponse> {
       ? valuesFiles.map((vf) => ({ vf, env: extractEnvName(vf) }))
       : [{ vf: undefined as string | undefined, env: "default" }];
 
-  const environments: EnvRenderResult[] = await Promise.all(
-    renderTargets.map(async ({ vf, env }) => {
+  const environments: EnvRenderResult[] = await runWithConcurrency(
+    renderTargets.map(({ vf, env }) => async () => {
       try {
         const vfArr = vf ? [vf] : [];
         const { yaml: rendered, jsRendererWarnings } = await runHelmTemplate(chartDir, "release", vfArr);
@@ -84,7 +105,8 @@ export async function renderChart(chartDir: string): Promise<NextResponse> {
           renderError: err instanceof Error ? err.message : String(err),
         } as EnvRenderResult;
       }
-    })
+    }),
+    RENDER_CONCURRENCY
   );
 
   return NextResponse.json({

--- a/lib/graphBuilder.ts
+++ b/lib/graphBuilder.ts
@@ -343,20 +343,83 @@ function inferEdges(resources: K8sResource[]): Edge[] {
     }
   }
 
+  function normalizeNamespace(namespace: unknown): string {
+    return typeof namespace === "string" && namespace.length > 0 ? namespace : "default";
+  }
+
+  function matchesLabelSelector(
+    selector: Record<string, unknown> | undefined,
+    labels: Record<string, string>,
+  ): boolean {
+    if (!selector) return false;
+
+    const matchLabels = selector.matchLabels as Record<string, string> | undefined;
+    const matchExpressions = selector.matchExpressions as
+      | Array<Record<string, unknown>>
+      | undefined;
+
+    const hasMatchLabels = !!matchLabels && Object.keys(matchLabels).length > 0;
+    const hasMatchExpressions = !!matchExpressions && matchExpressions.length > 0;
+    if (!hasMatchLabels && !hasMatchExpressions) return false;
+
+    const labelsMatch =
+      !hasMatchLabels ||
+      Object.entries(matchLabels).every(([k, v]) => labels[k] === v);
+
+    const expressionsMatch =
+      !hasMatchExpressions ||
+      matchExpressions.every((expression) => {
+        const key = expression.key;
+        const operator = expression.operator;
+        const values = Array.isArray(expression.values)
+          ? expression.values.filter((value): value is string => typeof value === "string")
+          : [];
+
+        if (typeof key !== "string" || typeof operator !== "string") return false;
+
+        switch (operator) {
+          case "In":
+            return key in labels && values.includes(labels[key]);
+          case "NotIn":
+            return !(key in labels) || !values.includes(labels[key]);
+          case "Exists":
+            return key in labels;
+          case "DoesNotExist":
+            return !(key in labels);
+          default:
+            return false;
+        }
+      });
+
+    return labelsMatch && expressionsMatch;
+  }
+
   // PodDisruptionBudget → Deployments via selector matching
   const pdbs = resources.filter((r) => r.kind === "PodDisruptionBudget");
   for (const pdb of pdbs) {
     const spec = pdb.spec as Record<string, unknown> | undefined;
-    const selector = (spec?.selector as Record<string, unknown> | undefined)?.matchLabels as Record<string, string> | undefined;
-    if (!selector || Object.keys(selector).length === 0) continue;
+    const selector = spec?.selector as Record<string, unknown> | undefined;
+    if (!selector) continue;
+
+    const pdbNamespace = normalizeNamespace(pdb.metadata?.namespace);
+    const hasSelectorRequirements =
+      (selector.matchLabels &&
+        Object.keys(selector.matchLabels as Record<string, unknown>).length > 0) ||
+      (Array.isArray(selector.matchExpressions) && selector.matchExpressions.length > 0);
+    if (!hasSelectorRequirements) continue;
+
     for (const dep of deployments) {
+      if (normalizeNamespace(dep.metadata?.namespace) !== pdbNamespace) continue;
+
       const depSpec = dep.spec as Record<string, unknown> | undefined;
       const template = depSpec?.template as Record<string, unknown> | undefined;
       const podMeta = template?.metadata as Record<string, unknown> | undefined;
       const podLabels = podMeta?.labels as Record<string, string> | undefined;
       if (!podLabels) continue;
-      const matches = Object.entries(selector).every(([k, v]) => podLabels[k] === v);
-      if (matches) addEdge(nodeId(pdb), nodeId(dep), "disruption budget for");
+
+      if (matchesLabelSelector(selector, podLabels)) {
+        addEdge(nodeId(pdb), nodeId(dep), "disruption budget for");
+      }
     }
   }
 

--- a/lib/graphBuilder.ts
+++ b/lib/graphBuilder.ts
@@ -30,6 +30,9 @@ const KNOWN_KINDS: Set<string> = new Set([
   "ClusterRoleBinding",
   "Role",
   "RoleBinding",
+  "NetworkPolicy",
+  "PodDisruptionBudget",
+  "CustomResourceDefinition",
 ]);
 
 function classifyKind(kind: string): K8sKind {
@@ -319,6 +322,41 @@ function inferEdges(resources: K8sResource[]): Edge[] {
         const sec = secretsByName.get(secName);
         if (sec) addEdge(nodeId(sec), nodeId(workload), "mounted by");
       }
+    }
+  }
+
+  // NetworkPolicy → Deployments via pod selector matching
+  const networkPolicies = resources.filter((r) => r.kind === "NetworkPolicy");
+  for (const np of networkPolicies) {
+    const spec = np.spec as Record<string, unknown> | undefined;
+    const podSelector = spec?.podSelector as Record<string, unknown> | undefined;
+    const matchLabels = podSelector?.matchLabels as Record<string, string> | undefined;
+    if (!matchLabels || Object.keys(matchLabels).length === 0) continue;
+    for (const dep of deployments) {
+      const depSpec = dep.spec as Record<string, unknown> | undefined;
+      const template = depSpec?.template as Record<string, unknown> | undefined;
+      const podMeta = template?.metadata as Record<string, unknown> | undefined;
+      const podLabels = podMeta?.labels as Record<string, string> | undefined;
+      if (!podLabels) continue;
+      const matches = Object.entries(matchLabels).every(([k, v]) => podLabels[k] === v);
+      if (matches) addEdge(nodeId(np), nodeId(dep), "selects pods");
+    }
+  }
+
+  // PodDisruptionBudget → Deployments via selector matching
+  const pdbs = resources.filter((r) => r.kind === "PodDisruptionBudget");
+  for (const pdb of pdbs) {
+    const spec = pdb.spec as Record<string, unknown> | undefined;
+    const selector = (spec?.selector as Record<string, unknown> | undefined)?.matchLabels as Record<string, string> | undefined;
+    if (!selector || Object.keys(selector).length === 0) continue;
+    for (const dep of deployments) {
+      const depSpec = dep.spec as Record<string, unknown> | undefined;
+      const template = depSpec?.template as Record<string, unknown> | undefined;
+      const podMeta = template?.metadata as Record<string, unknown> | undefined;
+      const podLabels = podMeta?.labels as Record<string, string> | undefined;
+      if (!podLabels) continue;
+      const matches = Object.entries(selector).every(([k, v]) => podLabels[k] === v);
+      if (matches) addEdge(nodeId(pdb), nodeId(dep), "disruption budget for");
     }
   }
 

--- a/lib/helmTemplateRenderer.ts
+++ b/lib/helmTemplateRenderer.ts
@@ -144,7 +144,7 @@ export async function renderHelmChartJS(
 
   // 4. Load all templates, collect {{ define }} blocks first
   const templatesDir = path.join(chartDir, "templates");
-  if (!existsSync(templatesDir)) return "";
+  if (!existsSync(templatesDir)) return { yaml: "", stubsUsed: [] };
 
   // Recursively collect all template files under a directory
   async function collectTemplateFiles(
@@ -203,22 +203,64 @@ export async function renderHelmChartJS(
     }
   }
 
-  // Second pass: render main-chart .yaml files only (skip subcharts and .tpl helpers)
+  // Second pass: render all .yaml templates (main chart + subcharts)
   const parts: string[] = [];
+
+  // Group template sources by origin (main chart vs subchart)
+  // relPath format for subcharts: "charts/<subchart>/templates/<file>"
+  const subchartNames = new Set<string>();
+  for (const { relPath } of templateSources) {
+    const m = relPath.match(/^charts\/([^/]+)\//);
+    if (m) subchartNames.add(m[1]);
+  }
+
+  // Build per-subchart render context (parent Values.<subchartName> as subchart Values)
+  const subchartContexts = new Map<string, HelmRenderContext>();
+  for (const scName of subchartNames) {
+    const scDir = path.join(chartsDir, scName);
+    let scValues: Record<string, unknown> = {};
+    const scDefaultValues = path.join(scDir, "values.yaml");
+    if (existsSync(scDefaultValues)) {
+      scValues = deepMerge(
+        scValues,
+        (yaml.load(await readFile(scDefaultValues, "utf-8")) as Record<string, unknown>) ?? {}
+      );
+    }
+    // Parent values override subchart defaults (Helm scoping)
+    const parentOverrides = (mergedValues[scName] ?? {}) as Record<string, unknown>;
+    scValues = deepMerge(scValues, parentOverrides);
+
+    // Load subchart Chart.yaml for metadata
+    let scChartName = scName;
+    let scChartVersion = "";
+    const scChartYamlPath = path.join(scDir, "Chart.yaml");
+    if (existsSync(scChartYamlPath)) {
+      const scMeta = yaml.load(await readFile(scChartYamlPath, "utf-8")) as Record<string, unknown>;
+      scChartName = String(scMeta.name ?? scName);
+      scChartVersion = String(scMeta.version ?? "");
+    }
+
+    subchartContexts.set(scName, {
+      Values: scValues,
+      Release: { ...ctx.Release },
+      Chart: { Name: scChartName, Version: scChartVersion, AppVersion: "", Description: "" },
+    });
+  }
+
   for (const { name, relPath, src } of templateSources) {
-    // Only render top-level chart templates (not from subcharts/charts/)
-    if (relPath.startsWith("charts/")) continue;
     if (name.endsWith(".tpl")) continue; // helpers-only files
     if (name === "NOTES.txt") continue;  // informational only
+
+    // Determine context: main chart or subchart
+    const scMatch = relPath.match(/^charts\/([^/]+)\//);
+    const renderCtx = scMatch ? (subchartContexts.get(scMatch[1]) ?? ctx) : ctx;
+
     try {
       const tokens = tokenize(src);
       const ast = parse(tokens);
-      // Seed $ with root context so $.Values.x works inside range/with
-      const initialScope: EvalScope = new Map([["$", ctx]]);
-      const rendered = evaluate(ast, ctx, namedTemplates, initialScope).trim();
+      const initialScope: EvalScope = new Map([["$", renderCtx]]);
+      const rendered = evaluate(ast, renderCtx, namedTemplates, initialScope).trim();
       if (rendered) {
-        // A single template file can produce multiple K8s resources.
-        // Split them into separate --- documents.
         const docs = splitRenderedDocs(rendered, name);
         parts.push(...docs);
       }

--- a/lib/helmTemplateRenderer.ts
+++ b/lib/helmTemplateRenderer.ts
@@ -233,17 +233,26 @@ export async function renderHelmChartJS(
     // Load subchart Chart.yaml for metadata
     let scChartName = scName;
     let scChartVersion = "";
+    let scChartAppVersion = "";
+    let scChartDescription = "";
     const scChartYamlPath = path.join(scDir, "Chart.yaml");
     if (existsSync(scChartYamlPath)) {
       const scMeta = yaml.load(await readFile(scChartYamlPath, "utf-8")) as Record<string, unknown>;
       scChartName = String(scMeta.name ?? scName);
       scChartVersion = String(scMeta.version ?? "");
+      scChartAppVersion = String(scMeta.appVersion ?? "");
+      scChartDescription = String(scMeta.description ?? "");
     }
 
     subchartContexts.set(scName, {
       Values: scValues,
       Release: { ...ctx.Release },
-      Chart: { Name: scChartName, Version: scChartVersion, AppVersion: "", Description: "" },
+      Chart: {
+        Name: scChartName,
+        Version: scChartVersion,
+        AppVersion: scChartAppVersion,
+        Description: scChartDescription,
+      },
     });
   }
 

--- a/types/helm.ts
+++ b/types/helm.ts
@@ -111,6 +111,9 @@ export type K8sKind =
   | "ClusterRoleBinding"
   | "Role"
   | "RoleBinding"
+  | "NetworkPolicy"
+  | "PodDisruptionBudget"
+  | "CustomResourceDefinition"
   | "Unknown";
 
 export interface ResourceNodeData extends Record<string, unknown> {


### PR DESCRIPTION
## Summary

Implements 5 enhancement issues:

### #67 — Loading indicator
- Added `isRendering` state to `app/page.tsx`
- Shows an animated spinner overlay on the graph area during workspace auto-load
- `ChartLoader` accepts `onRenderingChange` prop — toggles overlay during any fetch

### #68 — Subchart rendering
- Removed the `charts/` skip guard in `helmTemplateRenderer.ts`
- Each subchart is now rendered with its own Values context (parent `.Values.<subchartName>`)
- Subchart resources appear in the graph labelled with their subchart origin

### #72 — Parallel render throttle
- Added `runWithConcurrency<T>(tasks, concurrency)` helper in `chartRenderer.ts`
- Default concurrency: 3 (configurable via `RENDER_CONCURRENCY` constant)
- Prevents CPU spike when a chart has many value files / environments

### #73 — NetworkPolicy, PodDisruptionBudget, CRD passthrough
- Added to `K8sKind` union in `types/helm.ts`
- Added to `KNOWN_KINDS` set in `graphBuilder.ts`
- Edge inference: NetworkPolicy → matching Deployments via pod selector; PDB → matching Deployments via selector
- Badge colours added for all new kinds

### #75 — AI chat token/cost guard
- **Rate limiter**: in-memory sliding window, default 30 req/60 s per IP (env: `CHAT_RATE_LIMIT_MAX`, `CHAT_RATE_LIMIT_WINDOW_MS`)
- **Prompt size guard**: rejects requests >60 000 chars (~15k tokens) with HTTP 413
- **`max_tokens` cap**: default 1 200 output tokens (env: `OPENAI_MAX_TOKENS`)
